### PR TITLE
ci: add GitHub action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,30 @@
+name: Release DockerDesktop package
+
+on:
+  schedule:
+    - cron: '* 8 * * *' # scheduled at 08:00 everyday
+  workflow_dispatch: # on button click
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout DDCS
+        uses: actions/checkout@v4
+        with:
+          repository: "asxez/DDCS"
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "18.x"
+      - name: Set up Python
+        uses: actions/setup-python@v3
+        with:
+          python-version: "3.x"
+      - name: Release
+        run: ./release.sh
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -3,7 +3,9 @@
 
 Docker汉化  Docker中文版  Docker Desktop汉化 Docker Windows Docker MAC
 
-Windows arm 用户只能使用脚本进行汉化。这个架构的汉化包本仓库不予提供。
+~~Windows arm 用户只能使用脚本进行汉化。这个架构的汉化包本仓库不予提供。~~
+
+**注意: 自 4.39 版本后, 汉化 Asar 包会跟随 DockerDesktop 安装程序一起发布在 [Releases](https://github.com/asxez/DockerDesktop-CN/releases) 页面**
 <br>
 
 <font color=red>已发布汉化脚本，有需要的自行前往，但请遵守仓库相关许可，否则后果自负。</font>


### PR DESCRIPTION
**需要先合并 https://github.com/asxez/DDCS/pull/20** 

每天早八或手动运行, 比较并发布 release

action 实验: 
- 有新版本: https://github.com/black-06/DockerDesktop-CN/actions/runs/13713751579
- 无新版本: https://github.com/black-06/DockerDesktop-CN/actions/runs/13713825326

自动发布的 [release 示例](https://github.com/black-06/DockerDesktop-CN/releases/tag/4.39.0):

![img_v3_02k5_68a00e12-b296-4f18-b9d0-00ec87642ddg](https://github.com/user-attachments/assets/34899f91-82c0-4f52-ae86-e482794190e5)
